### PR TITLE
Send bans into the discord-admin channel

### DIFF
--- a/baseq3/server.cfg
+++ b/baseq3/server.cfg
@@ -103,4 +103,10 @@ set serverstartup "map campgrounds ca"
 // set serverstartup "map campgrounds ffa"
 
 set qlx_owner "76561198075972350"
-set qlx_plugins "plugin_manager, essentials, motd, permission, ban, silence, clan, names, log, workshop"
+set qlx_plugins "plugin_manager, essentials, motd, permission, ban, silence, clan, names, log, workshop, mydiscordbot"
+
+set qlx_discord_extensions "admin_events"
+set qlx_discordEnableBanLogs "1"
+set qlx_discordAdminEventsChannelId "1199846778019778660"
+set qlx_discordRelaxLogoUrl "https://i.postimg.cc/4N9FBrr2/Untitled-1.png"
+set qlx_discordBannedLogoUrl "https://img.freepik.com/vektoren-premium/verbotene-grunge-stempel-abzeichen-etiketten-isoliert-auf-weissem-hintergrund-editierbarer-splatter_567423-327.jpg"

--- a/minqlx-plugins/ban.py
+++ b/minqlx-plugins/ban.py
@@ -46,6 +46,9 @@ class ban(minqlx.Plugin):
         self.set_cvar_limit_once("qlx_leaverBanWarnThreshold", "0.78", "0", "1")
         self.set_cvar_once("qlx_leaverBanMinimumGames", "15")
 
+        # Discord related settings
+        self.set_cvar_once("qlx_discordEnableBanLogs", "0")
+
         # List of players playing that could potentially be considered leavers.
         self.players_start = []
         self.pending_warnings = {}
@@ -207,7 +210,16 @@ class ban(minqlx.Plugin):
             try:
                 self.kick(ident, "has been banned until ^6{}^7: {}".format(expires, reason))
             except ValueError:
-                channel.reply("^6{} ^7has been banned. Ban expires on ^6{}^7.".format(name, expires))
+                channel.reply("^6{} ^7has been banned. Ban expires on ^6{}^7...".format(name, expires))
+                self.trigger_discord_event({
+                    "server": self.get_cvar("sv_hostname"),
+                    "player": player,
+                    "ban_target": name,
+                    "reason": reason,
+                    "issued": now,
+                    "expires": expires,
+                    "term": f'{int(number)} {scale}'
+                })
 
     def cmd_unban(self, player, msg, channel):
         """Unbans a player if banned."""
@@ -399,3 +411,11 @@ class ban(minqlx.Plugin):
     def warn_player(self, player, ratio):
         player.tell("^7You have only completed ^6{}^7 percent of your games.".format(round(ratio * 100, 1)))
         player.tell("^7If you keep leaving you ^6will^7 be banned.")
+
+    def trigger_discord_event(self, ban_info):
+        if self.get_cvar("qlx_discordEnableBanLogs", bool) or False:
+            discord_plugin_name = "mydiscordbot"
+            if discord_plugin_name in minqlx.Plugin._loaded_plugins:
+                discord_bot = minqlx.Plugin._loaded_plugins[discord_plugin_name]
+                if discord_bot.discord.is_discord_logged_in():
+                    discord_bot.discord.discord.dispatch('ban_event', ban_info)

--- a/minqlx-plugins/ban.py
+++ b/minqlx-plugins/ban.py
@@ -210,7 +210,7 @@ class ban(minqlx.Plugin):
             try:
                 self.kick(ident, "has been banned until ^6{}^7: {}".format(expires, reason))
             except ValueError:
-                channel.reply("^6{} ^7has been banned. Ban expires on ^6{}^7...".format(name, expires))
+                channel.reply("^6{} ^7has been banned. Ban expires on ^6{}^7.".format(name, expires))
                 self.trigger_discord_event({
                     "server": self.get_cvar("sv_hostname"),
                     "player": player,

--- a/minqlx-plugins/discord_extensions/admin_events.py
+++ b/minqlx-plugins/discord_extensions/admin_events.py
@@ -1,0 +1,76 @@
+import asyncio
+
+from minqlx import Plugin
+
+from discord.ext.commands import Cog
+from discord import TextChannel
+from discord import Embed
+
+
+class AdminEventsCog(Cog):
+    """
+    Uses:
+    * qlx_discordAdminEventsChannelId (default: "") channel id to forward admin events towards
+    * qlx_discordRelaxLogoUrl (default: "") URL of the icon for discord Embed
+    * qlx_discordBannedLogoUrl (default: "") URL of the thumbnail for discord Embed
+    """
+
+    def __init__(self, bot):
+        Plugin.set_cvar_once("qlx_discordAdminEventsChannelId", "")
+        Plugin.set_cvar_once("qlx_discordRelaxLogoUrl", "")
+        Plugin.set_cvar_once("qlx_discordBannedLogoUrl", "")
+
+        self.bot = bot
+
+        self.discord_admin_events_channel_id = Plugin.get_cvar("qlx_discordAdminEventsChannelId", int) or -1
+        self.relax_logo = Plugin.get_cvar("qlx_discordRelaxLogoUrl") or ""
+        self.banned_logo = Plugin.get_cvar("qlx_discordBannedLogoUrl") or ""
+
+    @Cog.listener()
+    async def on_ban_event(self, ban_info):
+        embed = self.get_ban_embed(ban_info)
+        asyncio.run_coroutine_threadsafe(self.forward_embed_to_admin_channel(embed), loop=self.bot.loop)
+
+    def get_ban_embed(self, ban_info):
+        embed = Embed(color=0xe44407)
+        embed.set_author(name=ban_info["server"], icon_url=self.relax_logo)
+
+        # Choose one of the thumbnail or image property
+        # set_thumbnail adds a smaller image in the corner
+        # set_image adds a big image under the description
+        embed.set_thumbnail(url=self.banned_logo)
+        # embed.set_image(url=self.banned_logo)
+
+        # ban_info["reason"] comes in a format "reason text"
+        reason = ban_info["reason"]
+        if reason and reason.startswith("reason"):
+            reason = reason.split("reason ")[1]
+
+        embed.description = f'```' \
+                            f'Banned:     {ban_info["ban_target"]}' \
+                            f'\nReason:     {reason}' \
+                            f'\nTerm:       {ban_info["term"]}' \
+                            f'\nIssued:     {ban_info["issued"]}' \
+                            f'\nExpires:    {ban_info["expires"]}' \
+                            f'\nAdmin ID:   {ban_info["player"].steam_id}' \
+                            f'\nAdmin Name: {ban_info["player"].clean_name}' \
+                            f'```'
+        return embed
+
+    async def forward_msg_to_admin_channel(self, msg):
+        admin_channel = self.bot.get_channel(self.discord_admin_events_channel_id)
+        if admin_channel is None or not isinstance(admin_channel, TextChannel):
+            return
+
+        await admin_channel.send(content=msg)
+
+    async def forward_embed_to_admin_channel(self, embed):
+        admin_channel = self.bot.get_channel(self.discord_admin_events_channel_id)
+        if admin_channel is None or not isinstance(admin_channel, TextChannel):
+            return
+
+        await admin_channel.send(embed=embed)
+
+
+async def setup(bot):
+    await bot.add_cog(AdminEventsCog(bot))

--- a/minqlx-plugins/queue.py
+++ b/minqlx-plugins/queue.py
@@ -1,0 +1,416 @@
+# This is an extension plugin  for minqlx.
+# Copyright (C) 2016 mattiZed (github) aka mattiZed (ql)
+# Copyright (C) 2016 Melodeiro (github)
+
+# You can redistribute it and/or modify it under the terms of the
+# GNU General Public License as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+
+# You should have received a copy of the GNU General Public License
+# along with minqlx. If not, see <http://www.gnu.org/licenses/>.
+
+# This is a queue plugin written for Mino's Quake Live Server Mod minqlx.
+# Some parts of it were inspired by the original queueinfo plugin which was
+# written by WalkerX (github) for the old minqlbot.
+
+# The plugin put players to the queue when teams are full or even if match in progress.
+# When more players adding or there is the place for someone, guys from queue putting to the game.
+
+# The plugin also features an AFK list, to which players can
+# subscribe/unsubscribe to.
+
+# Its the alpha state, so any bugs might happen
+
+# For correctly updating the player tags after using !clan, server needs changed clan.py:
+# https://github.com/Melodeiro/minqlx-plugins_MinoMino/blob/master/clan.py
+# Also you can use the updated version of uneventeams.py, which will put players in queue:
+# https://github.com/Melodeiro/minqlx-plugins_mattiZed/blob/master/uneventeams.py
+
+import minqlx
+import time
+import threading
+
+TEAM_BASED_GAMETYPES = ("ca", "ctf", "dom", "ft", "tdm", "ad", "1f", "har")
+NONTEAM_BASED_GAMETYPES = ("ffa", "race", "rr")
+_tag_key = "minqlx:players:{}:clantag"
+
+
+class queue(minqlx.Plugin):
+    def __init__(self):
+        self.add_hook("new_game", self.handle_new_game)
+        self.add_hook("game_end", self.handle_game_end)
+        self.add_hook("player_loaded", self.handle_player_loaded)
+        self.add_hook("player_disconnect", self.handle_player_disconnect)
+        self.add_hook("team_switch", self.handle_team_switch)
+        self.add_hook("team_switch_attempt", self.handle_team_switch_attempt)
+        self.add_hook("set_configstring", self.handle_configstring, priority=minqlx.PRI_HIGH)
+        self.add_hook("client_command", self.handle_client_command)
+        self.add_hook("vote_ended", self.handle_vote_ended)
+        self.add_hook("console_print", self.handle_console_print)
+        self.add_command(("q", "queue"), self.cmd_lq)
+        self.add_command("afk", self.cmd_afk)
+        self.add_command("here", self.cmd_playing)
+        self.add_command("qversion", self.cmd_qversion)
+        self.add_command(("teamsize", "ts"), self.cmd_teamsize, priority=minqlx.PRI_HIGH)
+
+        # Commands for debugging
+        self.add_command("qpush", self.cmd_qpush, 5)
+        self.add_command("qadd", self.cmd_qadd, 5, usage="<id>")
+        self.add_command("qupd", self.cmd_qupd, 5)
+
+        self.version = "2.7.3"
+        self.plugin_updater_url = "https://raw.githubusercontent.com/Melodeiro/minqlx-plugins_mattiZed/master/queue.py"
+        self._queue = []
+        self._afk = []
+        self._tags = {}
+        self.initialize()
+        self.is_red_locked = False
+        self.is_blue_locked = False
+        self.is_push_pending = False
+        self.is_endscreen = self.game is None  # game is None is between game_end (probably) and new_game
+        self.set_cvar_once("qlx_queueSetAfkPermission", "2")
+        self.set_cvar_once("qlx_queueAFKTag", "^3AFK")
+
+        self.test_logger = minqlx.get_logger()
+
+    def initialize(self):
+        for p in self.players():
+            self.updTag(p)
+        self.unlock()
+
+    # Basic List Handling (Queue and AFK)
+    @minqlx.thread
+    def addToQueue(self, player, pos=-1):
+        '''Safely adds players to the queue'''
+        if player not in self._queue:
+            if pos == -1:
+                self._queue.append(player)
+            else:
+                self._queue.insert(pos, player)
+                for p in self._queue:
+                    self.updTag(p)
+            for p in self.teams()['spectator']:
+                self.center_print(p, "{} joined the Queue".format(player.name))
+        if player in self._queue:
+            self.center_print(player, "You are in the queue to play")
+        self.updTag(player)
+        self.pushFromQueue()
+
+    def remFromQueue(self, player, update=True):
+        '''Safely removes player from the queue'''
+        if player in self._queue:
+            # self.test_logger.warning("removing {} from queue".format(player))
+            self._queue.remove(player)
+        for p in self._queue:
+            self.updTag(p)
+        if update:
+            self.updTag(player)
+
+    @minqlx.thread
+    def pushFromQueue(self, delay=0):
+        '''Check if there is the place and players in queue, and put them in the game'''
+        @minqlx.next_frame
+        def pushToTeam(amount, team):
+            '''Safely put certain amout of players to the selected team'''
+            if not self.is_endscreen:
+                for count, player in enumerate(self._queue, start=1):
+                    if player in self.teams()['spectator'] and player.connection_state == 'active':
+                        # self.test_logger.warning("pop out {}".format(player))
+                        self._queue.pop(0).put(team)
+                    elif player.connection_state not in ['connected', 'primed']:
+                        self.remFromQueue(player)
+                    if count == amount:
+                        self.pushFromQueue(0.5)
+                        return
+
+        @minqlx.next_frame
+        def pushToBoth():
+            # TODO #
+            if len(self._queue) > 1 and not self.is_endscreen:
+                spectators = self.teams()['spectator']
+                if self._queue[0] in spectators and self._queue[0].connection_state == 'active':
+                    if self._queue[1] in spectators and self._queue[1].connection_state == 'active':
+                        # self.test_logger.warning("pop out {}".format(self._queue[0]))
+                        self._queue.pop(0).put("red")
+                        # self.test_logger.warning("pop out {}".format(self._queue[0]))
+                        self._queue.pop(0).put("blue")
+                    elif self._queue[1].connection_state not in ['connected', 'primed']:
+                        self.remFromQueue(self._queue[1])
+                elif self._queue[0].connection_state not in ['connected', 'primed']:
+                    self.remFromQueue(self._queue[0])
+                self.pushFromQueue(0.5)
+
+        @minqlx.next_frame
+        def checkForPlace():
+            if self.is_endscreen:
+                return
+            maxplayers = self.get_maxplayers()
+            teams = self.teams()
+            red_amount = len(teams["red"])
+            blue_amount = len(teams["blue"])
+            free_amount = len(teams["free"])
+
+            # self.msg("DEBUG max:{} ts:{} red:{} blue{} free:{}".format(maxplayers, self.game.teamsize, red_amount, blue_amount, free_amount))
+
+            if self.game.type_short in TEAM_BASED_GAMETYPES:
+                diff = red_amount - blue_amount
+                if diff > 0 and not self.is_blue_locked:
+                    pushToTeam(diff, "blue")
+                elif diff < 0 and not self.is_red_locked:
+                    pushToTeam(-diff, "red")
+                elif red_amount + blue_amount < maxplayers:
+                    if len(self._queue) > 1 and not self.is_blue_locked and not self.is_red_locked:
+                        pushToBoth()  # add elo here for those, who want
+                    elif self.game.state == 'warmup':  # for the case if there is 1 player in queue
+                        if not self.is_red_locked and red_amount < int(self.game.teamsize):
+                            pushToTeam(1, "red")
+                        elif not self.is_blue_locked and blue_amount < int(self.game.teamsize):
+                            pushToTeam(1, "blue")
+
+            elif self.game.type_short in NONTEAM_BASED_GAMETYPES:
+                if free_amount < maxplayers:
+                    pushToTeam(maxplayers - free_amount, "free")
+
+        if self.is_push_pending:
+            return
+        self.is_push_pending = True
+        time.sleep(delay)
+        self.is_push_pending = False
+
+        if len(self._queue) == 0:
+            return
+        if self.is_endscreen:
+            return
+        if self.game.state != 'in_progress' and self.game.state != 'warmup':
+            return
+
+        checkForPlace()
+
+    @minqlx.thread
+    def remAFK(self, player, update=True):
+        '''Safely removes players from afk list'''
+        if player in self._afk:
+            self._afk.remove(player)
+            if update:
+                self.updTag(player)
+
+    def posInQueue(self, player):
+        '''Returns position of the player in queue'''
+        try:
+            return self._queue.index(player)
+        except ValueError:
+            return -1
+
+    # AFK Handling
+    def setAFK(self, player):
+        '''Returns True if player's state could be set to AFK'''
+        if player in self.teams()['spectator'] and player not in self._afk:
+            self._afk.append(player)
+            self.remFromQueue(player)
+            return True
+        return False
+
+    @minqlx.thread
+    def remTag(self, player):
+        if player.steam_id in self._tags:
+            del self._tags[player.steam_id]
+
+    # @minqlx.thread
+    def updTag(self, player):
+        '''Update the tags dictionary and start the set_configstring event for tag to apply'''
+        @minqlx.next_frame
+        def upd():
+            if player in self.players():
+                player.clan = player.clan
+
+        if player in self.players():
+            addition = ""
+            position = self.posInQueue(player)
+
+            if position > -1:
+                addition = '({})'.format(position + 1)
+            elif player in self._afk:
+                addition = '({})'.format(self.get_cvar("qlx_queueAFKTag"))
+            elif self.game is not None and self.game.type_short not in TEAM_BASED_GAMETYPES + NONTEAM_BASED_GAMETYPES:
+                addition = ""
+            elif player in self.teams()['spectator']:
+                addition = '(s)'
+
+            self._tags[player.steam_id] = addition
+
+            upd()
+
+    @minqlx.next_frame
+    def center_print(self, player, message):
+        if player in self.players():
+            minqlx.send_server_command(player.id, "cp \"{}\"".format(message))
+
+    def get_maxplayers(self):
+        maxplayers = int(self.game.teamsize)
+        if self.game.type_short in TEAM_BASED_GAMETYPES:
+            maxplayers = maxplayers * 2
+        if maxplayers == 0:
+            maxplayers = self.get_cvar("sv_maxClients", int)
+        return maxplayers
+
+    # Plugin Handles and Commands
+    def handle_player_disconnect(self, player, reason):
+        self.remAFK(player, False)
+        self.remFromQueue(player, False)
+        self.remTag(player)
+        self.pushFromQueue(0.5)
+
+    def handle_player_loaded(self, player):
+        self.updTag(player)
+
+    def handle_team_switch(self, player, old_team, new_team):
+        if new_team != "spectator":
+            self.remFromQueue(player)
+            self.remAFK(player)
+        else:
+            self.updTag(player)
+            self.pushFromQueue(0.5)
+
+    def handle_team_switch_attempt(self, player, old_team, new_team):
+        if self.is_endscreen or self.game.type_short not in TEAM_BASED_GAMETYPES + NONTEAM_BASED_GAMETYPES:
+            return
+
+        if new_team != "spectator" and old_team == "spectator":
+            teams = self.teams()
+            maxplayers = self.get_maxplayers()
+            if len(teams["red"]) + len(teams["blue"]) == maxplayers or len(teams["free"]) == maxplayers or self.game.state == 'in_progress' or len(self._queue) > 0 or self.is_red_locked or self.is_blue_locked:
+                self.remAFK(player)
+                self.addToQueue(player)
+                return minqlx.RET_STOP_ALL
+
+    def cmd_qpush(self, player, msg, channel):
+        self.pushFromQueue()
+
+    def cmd_qadd(self, player, msg, channel):
+        if len(msg) < 2:
+            self.addToQueue(player)
+
+        try:
+            i = int(msg[1])
+            target_player = self.player(i)
+            if not (0 <= i < 64) or not target_player:
+                raise ValueError
+        except ValueError:
+            channel.reply("Invalid ID.")
+            return
+
+        self.addToQueue(target_player)
+
+    def cmd_qupd(self, player, msg, channel):
+        for p in self.players():
+            self.updTag(p)
+
+    def cmd_qversion(self, player, msg, channel):
+        channel.reply('^7This server has installed ^2queue.py {} ^7ver. by ^3Melod^1e^3iro'.format(self.version))
+
+    def handle_client_command(self, player, command):
+        @minqlx.thread
+        def handler():
+            if command == "team s":
+                if player in self.teams()['spectator']:
+                    self.remFromQueue(player)
+                    if player not in self._queue:
+                        self.center_print(player, "You are set to spectate only")
+        handler()
+
+    def handle_vote_ended(self, votes, vote, args, passed):
+        if vote == "teamsize":
+            self.pushFromQueue(4)
+
+    def handle_configstring(self, index, value):
+        if not value:
+            return
+
+        elif 529 <= index < 529 + 64:
+            try:
+                player = self.player(index - 529)
+            except minqlx.NonexistentPlayerError:
+                return
+
+            if player.steam_id in self._tags:
+                tag = self._tags[player.steam_id]
+
+                tag_key = _tag_key.format(player.steam_id)
+                if tag_key in self.db:
+                    if len(tag) > 0:
+                        tag += ' '
+                    tag += self.db[tag_key]
+
+                cs = minqlx.parse_variables(value, ordered=True)
+                cs["xcn"] = tag
+                cs["cn"] = tag
+                new_cs = "".join(["\\{}\\{}".format(key, cs[key]) for key in cs])
+                return new_cs
+
+    def handle_new_game(self):
+        self.is_endscreen = False
+        self.is_red_locked = False
+        self.is_blue_locked = False
+
+        if self.game.type_short not in TEAM_BASED_GAMETYPES + NONTEAM_BASED_GAMETYPES:
+            # self.test_logger.warning("Emptying queue")
+            self._queue = []
+            for p in self.players():
+                self.updTag(p)
+        else:
+            self.pushFromQueue()
+
+    def handle_game_end(self, data):
+        self.is_endscreen = True
+
+    def cmd_lq(self, player, msg, channel):
+        msg = "^7No one in queue."
+        if self._queue:
+            msg = "^1Queue^7 >> "
+            count = 1
+            for p in self._queue:
+                msg += '{}^7({}) '.format(p.name, count)
+                count += 1
+        channel.reply(msg)
+
+        if self._afk:
+            msg = "^3Away^7 >> "
+            for p in self._afk:
+                msg += p.name + " "
+
+            channel.reply(msg)
+
+    def cmd_afk(self, player, msg, channel):
+        if len(msg) > 1:
+            if self.db.has_permission(player, self.get_cvar("qlx_queueSetAfkPermission", int)):
+                guy = self.find_player(msg[1])[0]
+                if self.setAFK(guy):
+                    player.tell("^7Status for {} has been set to ^3AFK^7.".format(guy.name))
+                    return minqlx.RET_STOP_ALL
+                else:
+                    player.tell("Couldn't set status for {} to AFK.".format(guy.name))
+                    return minqlx.RET_STOP_ALL
+        if self.setAFK(player):
+            player.tell("^7Your status has been set to ^3AFK^7.")
+        else:
+            player.tell("^7Couldn't set your status to AFK.")
+
+    def cmd_playing(self, player, msg, channel):
+        self.remAFK(player)
+        self.updTag(player)
+        player.tell("^7Your status has been set to ^2AVAILABLE^7.")
+
+    def cmd_teamsize(self, playing, msg, channel):
+        self.pushFromQueue(0.5)
+
+    def handle_console_print(self, text):
+        if text.find('broadcast: print "The RED team is now locked') != -1:
+            self.is_red_locked = True
+        elif text.find('broadcast: print "The BLUE team is now locked') != -1:
+            self.is_blue_locked = True
+        elif text.find('broadcast: print "The RED team is now unlocked') != -1:
+            self.is_red_locked = False
+            self.pushFromQueue(0.5)  # if cause errors maybe call that in next_frame
+        elif text.find('broadcast: print "The BLUE team is now unlocked') != -1:
+            self.is_blue_locked = False
+            self.pushFromQueue(0.5)

--- a/minqlx-plugins/queue.py
+++ b/minqlx-plugins/queue.py
@@ -296,10 +296,6 @@ class queue(minqlx.Plugin):
                 self.remove_afk(player)
                 self.add_to_queue(player)
                 return minqlx.RET_STOP_ALL
-        else:
-            self.update_tag(player)
-            self.take_from_queue(0.5)
-            return minqlx.RET_STOP_ALL
 
     def cmd_queue_version(self, player, msg, channel):
         channel.reply('^7This server has installed ^2queue.py {} ^7ver. by ^3Melod^1e^3iro'.format(self.version))


### PR DESCRIPTION
How to add it into your server:
- Add a new plugin into your existing plugins list:
`set qlx_plugins "<...>, mydiscordbot"`
- Add new config settings (setup your `qlx_discordAdminEventsChannelId`):
```
set qlx_discord_extensions "admin_events"
set qlx_discordEnableBanLogs "1"
set qlx_discordAdminEventsChannelId "1199846778019778660"
set qlx_discordRelaxLogoUrl "https://i.postimg.cc/4N9FBrr2/Untitled-1.png"
set qlx_discordBannedLogoUrl "https://img.freepik.com/vektoren-premium/verbotene-grunge-stempel-abzeichen-etiketten-isoliert-auf-weissem-hintergrund-editierbarer-splatter_567423-327.jpg"
```
- Small update on the existing `ban.py` to trigger the discord event when ban is complete
- Put new `admin_events.py` into the `minqlx-plugins/discord_extensions` folder

ps: there is a slight dependency in bans.py on the external discord module (not a direct import though; it does not break anything)